### PR TITLE
Add context to page and menu title "Activity Log" strings

### DIFF
--- a/classes/class-aal-admin-ui.php
+++ b/classes/class-aal-admin-ui.php
@@ -13,7 +13,7 @@ class AAL_Admin_Ui {
 	public function create_admin_menu() {
 		$menu_capability = current_user_can( 'view_all_aryo_activity_log' ) ? 'view_all_aryo_activity_log' : 'edit_pages';
 		
-		$this->_screens['main'] = add_menu_page( __( 'Activity Log', 'aryo-activity-log' ), __( 'Activity Log', 'aryo-activity-log' ), $menu_capability, 'activity_log_page', array( &$this, 'activity_log_page_func' ), '', '2.1' );
+		$this->_screens['main'] = add_menu_page( _x( 'Activity Log', 'Page and Menu Title', 'aryo-activity-log' ), _x( 'Activity Log', 'Page and Menu Title', 'aryo-activity-log' ), $menu_capability, 'activity_log_page', array( &$this, 'activity_log_page_func' ), '', '2.1' );
 		
 		// Just make sure we are create instance.
 		add_action( 'load-' . $this->_screens['main'], array( &$this, 'get_list_table' ) );
@@ -23,7 +23,7 @@ class AAL_Admin_Ui {
 		$this->get_list_table()->prepare_items();
 		?>
 		<div class="wrap">
-			<h1 class="aal-page-title"><?php _e( 'Activity Log', 'aryo-activity-log' ); ?></h1>
+			<h1 class="aal-page-title"><?php _ex( 'Activity Log', 'Page and Menu Title', 'aryo-activity-log' ); ?></h1>
 
 			<form id="activity-filter" method="get">
 				<input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>" />


### PR DESCRIPTION
Adding this context will allow to separate Plugin Name from page and menu titles.
The Plugin Name **shouldn't be translated**, keeping the original is the best practice, as is the name it is known and it have a reputation built across languages.
The page and menu titles can/should be translated to improve usability.
This is a common problem where the plugin name is exactly it's function and menu title, also very common in simple and straight forward plugin names :)