### PR TITLE
Fix callings of WPDB::prepare due to core documentation

### DIFF
--- a/classes/class-aal-activity-log-list-table.php
+++ b/classes/class-aal-activity-log-list-table.php
@@ -258,27 +258,25 @@ class AAL_Activity_Log_List_Table extends WP_List_Table {
 
 		echo '<div class="alignleft actions">';
 
-		$users = $wpdb->get_results( $wpdb->prepare(
-			'SELECT DISTINCT %1$s FROM `%2$s`
+		$users_group_by = 'user_id';
+		$users = $wpdb->get_results(
+			'SELECT DISTINCT `' . $users_group_by . '` FROM `' . $wpdb->activity_log . '`
 				WHERE 1 = 1
 				' . $this->_get_where_by_role() . '
-				GROUP BY `%1$s`
-				ORDER BY `%1$s`
-			;',
-			'user_id',
-			$wpdb->activity_log
-		) );
+				GROUP BY `' . $users_group_by . '`
+				ORDER BY `' . $users_group_by . '`
+			;' 
+		);
 
-		$types = $wpdb->get_results( $wpdb->prepare(
-			'SELECT DISTINCT %1$s FROM `%2$s`
+		$types_group_by = 'object_type';
+		$types = $wpdb->get_results( 
+			'SELECT DISTINCT `' . $types_group_by . '` FROM `' . $wpdb->activity_log . '`
 				WHERE 1 = 1
 				' . $this->_get_where_by_role() . '
-				GROUP BY `%1$s`
-				ORDER BY `%1$s`
-			;',
-			'object_type',
-			$wpdb->activity_log
-		) );
+				GROUP BY `' . $types_group_by . '`
+				ORDER BY `' . $types_group_by . '`
+			;'
+		);
 
 		// Make sure we get items for filter.
 		if ( $users || $types ) {
@@ -357,17 +355,15 @@ class AAL_Activity_Log_List_Table extends WP_List_Table {
 			echo '</select>';
 		}
 
-
-		$actions = $wpdb->get_results( $wpdb->prepare(
-			'SELECT DISTINCT %1$s FROM `%2$s`
+		$actions_group_by = 'action';
+		$actions = $wpdb->get_results(
+			'SELECT DISTINCT `' . $actions_group_by . '` FROM `' . $wpdb->activity_log . '`
 				WHERE 1 = 1
 				' . $this->_get_where_by_role() . '
-				GROUP BY `%1$s`
-				ORDER BY `%1$s`
-			;',
-			'action',
-			$wpdb->activity_log
-		) );
+				GROUP BY `' . $actions_group_by . '`
+				ORDER BY `' . $actions_group_by . '`
+			;'
+		);
 
 		if ( $actions ) {
 			if ( ! isset( $_REQUEST['showaction'] ) )
@@ -432,7 +428,7 @@ class AAL_Activity_Log_List_Table extends WP_List_Table {
 				$start_time = strtotime( '-1 month', $start_time );
 			}
 			
-			$where .= $wpdb->prepare( ' AND `hist_time` > %1$d AND `hist_time` < %2$d', $start_time, $end_time );
+			$where .= $wpdb->prepare( ' AND `hist_time` > %d AND `hist_time` < %d', $start_time, $end_time );
 		}
 
 		if ( isset( $_REQUEST['s'] ) ) {
@@ -443,24 +439,25 @@ class AAL_Activity_Log_List_Table extends WP_List_Table {
 		$offset = ( $this->get_pagenum() - 1 ) * $items_per_page;
 
 		
-		$total_items = $wpdb->get_var( $wpdb->prepare(
-			'SELECT COUNT(`histid`) FROM `%1$s`
+		$total_items = $wpdb->get_var( 
+			'SELECT COUNT(`histid`) FROM `' . $wpdb->activity_log . '`
 				' . $where . '
-					' . $this->_get_where_by_role(),
-			$wpdb->activity_log,
-			$offset,
-			$items_per_page
-		) );
+					' . $this->_get_where_by_role() 
+		);
 		
+		
+		$items_orderby = filter_input(INPUT_GET, 'orderby', FILTER_SANITIZE_STRING);
+		$items_order = strtoupper($_REQUEST['order']);
+		if($items_order !== 'DESC' && $items_order !== 'ASC') {
+			$items_order = 'DESC'; // order by default
+		}
+
 		$this->items = $wpdb->get_results( $wpdb->prepare(
-			'SELECT * FROM `%1$s`
+			'SELECT * FROM `' . $wpdb->activity_log . '`
 				' . $where . '
 					' . $this->_get_where_by_role() . '
-					ORDER BY `%2$s` %3$s
-					LIMIT %4$d, %5$d;',
-			$wpdb->activity_log,
-			$_REQUEST['orderby'],
-			$_REQUEST['order'],
+					ORDER BY `' . $items_orderby . '` ' . $items_order . '
+					LIMIT %d, %d;',
 			$offset,
 			$items_per_page
 		) );

--- a/classes/class-aal-api.php
+++ b/classes/class-aal-api.php
@@ -17,9 +17,8 @@ class AAL_API {
 		
 		$wpdb->query(
 			$wpdb->prepare(
-				'DELETE FROM `%1$s`
-					WHERE `hist_time` < %2$d',
-				$wpdb->activity_log,
+				'DELETE FROM `' . $wpdb->activity_log . '`
+					WHERE `hist_time` < %d',
 				strtotime( '-' . $logs_lifespan . ' days', current_time( 'timestamp' ) )
 			)
 		);
@@ -107,19 +106,18 @@ class AAL_API {
 			$args['user_caps'] = 'administrator';
 		
 		// Make sure for non duplicate.
-		$check_duplicate = $wpdb->get_row(
+		$check_duplicate = $wpdb->get_row( // !!!
 			$wpdb->prepare(
-				'SELECT `histid` FROM %1$s
-					WHERE `user_caps` = \'%2$s\'
-						AND `action` = \'%3$s\'
-						AND `object_type` = \'%4$s\'
-						AND `object_subtype` = \'%5$s\'
-						AND `object_name` = \'%6$s\'
-						AND `user_id` = \'%7$s\'
-						AND `hist_ip` = \'%8$s\'
-						AND `hist_time` = \'%9$s\'
+				'SELECT `histid` FROM `' . $wpdb->activity_log . '`
+					WHERE `user_caps` = \'%s\'
+						AND `action` = \'%s\'
+						AND `object_type` = \'%s\'
+						AND `object_subtype` = \'%s\'
+						AND `object_name` = \'%s\'
+						AND `user_id` = \'%s\'
+						AND `hist_ip` = \'%s\'
+						AND `hist_time` = \'%s\'
 				;',
-				$wpdb->activity_log,
 				$args['user_caps'],
 				$args['action'],
 				$args['object_type'],


### PR DESCRIPTION
**First**, I fixed table name in placeholders. Lines like this is incorrect:
> SELECT * FROM `%1$s`

You should not swap out the tablename. If you do, the table name will be wrapped in quotes and it will trigger a SQL error in some (depend of server) cases.

`prepare()` is meant to operate on user supplied data - data that could be from questionable sourced with malicious intent. You do not need to swap out data, like your table name, that is not from a questionable source. So I fixed it in all places with the same "backtick problem" (keywords, column names, etc).

**Second**, Wordpress `prepare()` method haven't support for numerated placeholders anymore. Early, it was possible to call `prepare()` with placeholders like `%1$s`, but due to [this issue](https://medium.com/websec/wordpress-sqli-bbb2afcc8e94) and starts from Wordpress 4.8.2 and higher, its impossible. Ticket and discussion about numerated placeholders is here: https://core.trac.wordpress.org/ticket/41925

I replaced all placeholders with position specifier to common placeholders which have a full support.