### PR TITLE
Fix: Request-URI Too Long error

### DIFF
--- a/classes/class-aal-activity-log-list-table.php
+++ b/classes/class-aal-activity-log-list-table.php
@@ -241,9 +241,9 @@ class AAL_Activity_Log_List_Table extends WP_List_Table {
 	}
 	
 	public function display_tablenav( $which ) {
-		if ( 'top' == $which )
+		if ( 'top' == $which ) {
 			$this->search_box( __( 'Search', 'aryo-activity-log' ), 'aal-search' );
-			wp_nonce_field( 'bulk-' . $this->_args['plural'] );
+		}
 		?>
 		<div class="tablenav <?php echo esc_attr( $which ); ?>">
 			<?php


### PR DESCRIPTION
After filtering the log a few times a **Request-URI Too Long** error will be thrown due to the URL length exceeding the capacity limit for most servers. This is caused by the `_wpnonce` and `_wp_http_referer` parameters being added to the URI multiple times.

The `wp_none_field()` function isn't currently being used for anything in this plugin and as such can be removed, fixing the above issue.

As reported here [Crazy-long URL after using filters](https://wordpress.org/support/topic/crazy-long-url-after-using-filters/) and here [Bad request after multiple filter changes](https://wordpress.org/support/topic/bad-request-after-multiple-filter-changes/)