### PR TITLE
Fix: Travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,13 @@ env:
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-
-#after_success:
-#    - bash <(curl -s https://codecov.io/bash)
+    - export PATH="$HOME/.composer/vendor/bin:$PATH" 
+    - | 
+      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then 
+        composer global require "phpunit/phpunit=5.7.*" 
+      else 
+        composer global require "phpunit/phpunit=4.8.*" 
+      fi
+    - phpunit --version
 
 script: phpunit --coverage-clover=coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
-# Travis CI Configuration File
-
+# Travis CI Configuration File.
 sudo: false
-
-# Tell Travis CI we're using PHP
 language: php
 
-# PHP version used in first build configuration.
+# PHP versions to run tests against.
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7.0
 
-# WordPress version used in first build configuration.
+# WordPress versions to run tests against.
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@
 sudo: false
 language: php
 
+# Caching to improve build times.
+cache:
+  apt: true
+  directories:
+    - node_modules
+    - vendor
+    - $HOME/.composer/cache
+
 # PHP versions to run tests against.
 php:
     - 5.4
@@ -23,6 +31,12 @@ env:
     - WP_VERSION=4.7 WP_MULTISITE=1
 
 before_script:
+    - |
+      if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+        phpenv config-rm xdebug.ini
+      else
+        echo "xdebug.ini does not exist"
+      fi
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
     - export PATH="$HOME/.composer/vendor/bin:$PATH" 
     - | 


### PR DESCRIPTION
It looks like the Travis build has been failing for some time, this is due to changes made on the Travis build servers (OS Upgrades, PHPUnit update etc).

**Changes made by this pull request:**

- **Fix:** PHPUnit errors on PHP 7
_Conditionally use different PHPUnit versions depending on the current version of PHP being used by the build instance._

- **Remove:** Testing of plugin on PHP 5.3
_PHP 5.3 is no longer supported on the Travis build server, as it is now using Ubuntu Trusty by default. We can set up conditionals to run the PHP 5.3 tests on Ubuntu Precise, but for now, we'll just remove testing on PHP 5.3._

- **Change:** Improve Travis build performance
_Improve the Travis build performance by adding caching and disabling XDebug._